### PR TITLE
Fix typo in `WalletType.ETHERIUM` across the codebase

### DIFF
--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -89,7 +89,7 @@ export async function saveWalletToFS(
         content,
         'application/x-pem-file',
       )
-    case WalletType.ETHERIUM:
+    case WalletType.ETHEREUM:
       return await saveToDevice(`${address}.key`, key, 'application/x-pem-file')
   }
 }

--- a/src/screens/Wallet/index.tsx
+++ b/src/screens/Wallet/index.tsx
@@ -76,7 +76,7 @@ export function Wallet({}: NativeStackScreenProps<
           changeScreenState(SCREEN_STATE.LOADED)
         })
         break
-      case WalletType.ETHERIUM:
+      case WalletType.ETHEREUM:
         const account = privateKeyToAccount(wallet.privateKey)
 
         const publicClient = createTestClient({
@@ -213,7 +213,7 @@ export function Wallet({}: NativeStackScreenProps<
     )
   } else if (undefined !== walletState) {
     const coinName: string =
-      walletState.wallet.walletType === WalletType.ETHERIUM ? 'WEI' : 'F1R3CAP'
+      walletState.wallet.walletType === WalletType.ETHEREUM ? 'WEI' : 'F1R3CAP'
 
     return (
       <Layout.Screen>

--- a/src/state/queries/wallet.ts
+++ b/src/state/queries/wallet.ts
@@ -142,7 +142,7 @@ export function useTransferMutation(wallet: FireCAPWallet | EtheriumWallet) {
   return useMutation({
     mutationFn: async (props: TransferProps) => {
       switch (wallet.walletType) {
-        case WalletType.ETHERIUM:
+        case WalletType.ETHEREUM:
           return sendByEther(props)
         case WalletType.F1R3CAP:
           return sendByF1r3Cap(props)

--- a/src/state/wallets.tsx
+++ b/src/state/wallets.tsx
@@ -3,7 +3,7 @@ import {type Hex} from 'viem'
 
 export enum WalletType {
   F1R3CAP = 'F1R3CAP',
-  ETHERIUM = 'etherium',
+  ETHEREUM = 'ethereum',
 }
 
 export type WalletKey = Uint8Array | Hex
@@ -19,7 +19,7 @@ export type EtheriumWallet = {
   privateKey: Hex
   publicKey: Hex
   address: Hex
-  walletType: WalletType.ETHERIUM
+  walletType: WalletType.ETHEREUM
 }
 
 export type UniWallet = FireCAPWallet | EtheriumWallet
@@ -46,7 +46,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   function addWallet(key: UniWallet): number {
     const newWallets = [...wallets, key]
     setWallets(newWallets)
-    return newWallets.length - 1
+    return newWallets.length
   }
 
   function getAll(): UniWallet[] {

--- a/src/view/com/modals/AddWallet.tsx
+++ b/src/view/com/modals/AddWallet.tsx
@@ -74,7 +74,7 @@ export function Component() {
             privateKey: content as WalletKey,
             publicKey: client.publicKey,
             address: client.address,
-            walletType: WalletType.ETHERIUM,
+            walletType: WalletType.ETHEREUM,
           } as EtheriumWallet
         }
       })

--- a/src/view/com/modals/WalletTransfer.tsx
+++ b/src/view/com/modals/WalletTransfer.tsx
@@ -45,7 +45,7 @@ export function Component({currentBalance, wallet}: Props) {
   const {mutateAsync: submit, isPending} = useTransferMutation(wallet)
 
   const currencySymbol =
-    wallet.walletType === WalletType.ETHERIUM ? 'WEI' : 'F1R3CAP'
+    wallet.walletType === WalletType.ETHEREUM ? 'WEI' : 'F1R3CAP'
 
   return (
     <SafeAreaView style={[pal.view, a.flex_1]}>


### PR DESCRIPTION
- Corrected spelling from 'etherium' to 'ETHEREUM' - Updated related
logic and constants
