### PR TITLE
Updates version of better-sqlite3 for node 24 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "base64-js": "^1.5.1",
     "bcp-47": "^2.1.0",
     "bcp-47-match": "^2.0.3",
+    "better-sqlite3": "^12.4.1",
     "blakejs": "^1.2.1",
     "date-fns": "^2.30.0",
     "deprecated-react-native-prop-types": "^5.0.0",
@@ -289,10 +290,11 @@
     "@react-native/babel-preset": "0.79.3",
     "@react-native/normalize-colors": "0.79.3",
     "@types/react": "^18",
+    "**/better-sqlite3": "^12.4.1",
     "**/expo-constants": "17.0.3",
     "**/expo-device": "7.1.4",
-    "**/zod": "3.23.8",
-    "**/multiformats": "9.9.0"
+    "**/multiformats": "9.9.0",
+    "**/zod": "3.23.8"
   },
   "jest": {
     "preset": "jest-expo/ios",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9069,10 +9069,10 @@ better-opn@~3.0.2:
   dependencies:
     open "^8.0.4"
 
-better-sqlite3@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-10.1.0.tgz#8dc07e496fc014a7cd2211f79e591f6ba92838e8"
-  integrity sha512-hqpHJaCfKEZFaAWdMh6crdzRWyzQzfP6Ih8TYI0vFn01a6ZTDSbJIMXN+6AMBaBOh99DzUy8l3PsV9R3qnJDng==
+better-sqlite3@^10.0.0, better-sqlite3@^12.4.1:
+  version "12.4.1"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.4.1.tgz#f78df6c80530d1a0b750b538033e6199b7d30d26"
+  integrity sha512-3yVdyZhklTiNrtg+4WqHpJpFDd+WHTg2oM7UcR80GqL05AOV0xEJzc6qNvFYoEtE+hRp1n9MpN6/+4yhlGkDXQ==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^7.1.1"


### PR DESCRIPTION
This forces dependence on the latest version of `better-sqlite3` to support the latest version of `node`. Without the resolution override, `yarn` wants to install an older version of `better-sqlite3` that is incompatible with `node` 24.